### PR TITLE
Allow surveydown to use environment variables set outside .env file

### DIFF
--- a/R/db.R
+++ b/R/db.R
@@ -214,6 +214,9 @@ sd_db_connect <- function(
   if (file.exists(env_file)) {
     dotenv::load_dot_env(env_file)
   }
+  else {
+    cli::cli_alert_info("No .env file found. Will attempt existing environment variables.")
+  }
 
   # Try to get all required parameters
   params <- list(


### PR DESCRIPTION
I am working on using surveydown via a docker setup, so I would like to pass the `.env` values to surveydown as environment variables in the shell, rather than giving the container access to the `.env` file. 

The change I made should not effect users normal workflow. 

1. It sources the `.env` file if it is available, then it runs the sys.getenv() lines regardless.
2. They will just be empty strings if `.env` is missing and they are not previously set. 
3. It then gives the warning if they are all empty to run sd_db_config() as before.