### PR TITLE
Fix bug: Allow multiple themes e.g., `theme: [default, custom.scss]`

### DIFF
--- a/R/ui.R
+++ b/R/ui.R
@@ -55,7 +55,7 @@ sd_ui <- function() {
 
   theme <- get_theme(metadata)
   default_theme <- FALSE
-  if (length(theme) > 0 && "default" %in% theme) {
+  if ("default" %in% theme) {
     default_theme <- TRUE
   }
   barcolor <- get_barcolor(metadata)
@@ -504,7 +504,7 @@ render_survey_qmd <- function(paths, default_theme = TRUE, theme = NULL) {
 
   # Add theme to render_metadata if provided
   # This allows themes defined under theme-settings to be applied by Quarto
-  if (!is.null(theme) && length(theme) > 0 && !all(theme == "default")) {
+  if (!is.null(theme) && !all(theme == "default")) {
     render_metadata$theme <- theme
   }
 


### PR DESCRIPTION
I found a small logic bug this morning when doing custom styling. This solves the following error which tries to coerce a vector of length > 1 to a logical, e.g., `theme: [default, custom.scss]`: 

```
Changes detected...rendering survey files...
Error in !is.null(theme) && theme != "default" : 
  'length = 2' in coercion to 'logical(1)'
```

<img width="526" height="440" alt="image" src="https://github.com/user-attachments/assets/2275cb2c-c566-40b9-bc8f-34cad99f2faa" />
