### PR TITLE
Enhancement: Restart survey and clear cookies

### DIFF
--- a/R/messages.R
+++ b/R/messages.R
@@ -62,6 +62,7 @@ get_messages_default <- function() {
             "previous" = "Previous",
             "next" = "Next",
             "exit" = "Exit Survey",
+            "restart" = "Restart Survey",
             "close-tab" = "Please close this tab manually to exit the survey.",
             "choose-option" = "Choose an option...",
             "click" = "Click here",
@@ -85,6 +86,7 @@ get_messages_default <- function() {
             "previous" = "Zur\u00fcck",
             "next" = "Weiter",
             "exit" = "Umfrage beenden",
+            "restart" = "Umfrage neu starten",
             "close-tab" = "Bitte schlie\u00dfen Sie diesen Tab manuell, um die Umfrage zu beenden.",
             "choose-option" = "Option ausw\u00e4hlen...",
             "click" = "Hier klicken",
@@ -108,6 +110,7 @@ get_messages_default <- function() {
             "previous" = "Anterior",
             "next" = "Siguiente",
             "exit" = "Salir de la Encuesta",
+            "restart" = "Reiniciar Encuesta",
             "close-tab" = "Por favor, cierre esta pesta\u00f1a manualmente para salir de la encuesta.",
             "choose-option" = "Elija una opci\u00f3n...",
             "click" = "Haga clic aqu\u00ed",
@@ -131,6 +134,7 @@ get_messages_default <- function() {
             "previous" = "Pr\u00e9c\u00e9dent",
             "next" = "Suivant",
             "exit" = "Quitter le sondage",
+            "restart" = "Redémarrer le sondage",
             "close-tab" = "Veuillez fermer cet onglet manuellement pour quitter le sondage.",
             "choose-option" = "Choisissez une option...",
             "click" = "Cliquez ici",
@@ -154,6 +158,7 @@ get_messages_default <- function() {
             "previous" = "Indietro",
             "next" = "Avanti",
             "exit" = "Esci dal Sondaggio",
+            "restart" = "Riavvia Sondaggio",
             "close-tab" = "Per favore, chiudi questa scheda manualmente per uscire dal sondaggio.",
             "choose-option" = "Scegli un'opzione...",
             "click" = "Clicca qui",
@@ -177,6 +182,7 @@ get_messages_default <- function() {
             "previous" = "\u4e0a\u4e00\u9875", # \u4e0a\u4e00\u9875
             "next" = "\u4e0b\u4e00\u9875", # \u4e0b\u4e00\u9875
             "exit" = "\u9000\u51fa\u95ee\u5377", # \u9000\u51fa\u95ee\u5377
+            "restart" = "\u91cd\u65b0\u5f00\u59cb\u95ee\u5377", # \u91cd\u65b0\u5f00\u59cb\u95ee\u5377
             "close-tab" = "\u8bf7\u624b\u52a8\u5173\u95ed\u672c\u9875\u9762\u3002", # \u8bf7\u624b\u52a8\u5173\u95ed\u672c\u9875\u9762\u3002
             "choose-option" = "\u8bf7\u9009\u62e9\u4e00\u9879\u2026", # \u8bf7\u9009\u62e9\u4e00\u9879\u2026
             "click" = "\u5355\u51fb\u6b64\u5904", # \u5355\u51fb\u6b64\u5904

--- a/R/server.R
+++ b/R/server.R
@@ -2195,6 +2195,9 @@ sd_server <- function(
 
     # Observer to handle the rating submission or exit confirmation
     shiny::observeEvent(input$submit_rating, {
+        # Check if cookies should be cleared on exit
+        clear_cookies_on_exit <- input$clear_cookies_on_exit
+        
         # Save the rating
         rating <- input$survey_rating
         all_data[['exit_survey_rating']] <- rating
@@ -2203,19 +2206,45 @@ sd_server <- function(
         shiny::isolate({
             update_data(time_last = TRUE)
         })
+        
+        # Clear cookies if requested
+        if (!is.null(clear_cookies_on_exit) && clear_cookies_on_exit) {
+            session$sendCustomMessage("clearCookies", list())
+        }
+        
         # Close the modal and the window
         shiny::removeModal()
         session$sendCustomMessage("closeWindow", list())
     })
 
     shiny::observeEvent(input$confirm_exit, {
+        # Check if cookies should be cleared on exit
+        clear_cookies_on_exit <- input$clear_cookies_on_exit
+        
         # Update checkpoint 4 - when exiting survey
         shiny::isolate({
             update_data(time_last = TRUE)
         })
+        
+        # Clear cookies if requested
+        if (!is.null(clear_cookies_on_exit) && clear_cookies_on_exit) {
+            session$sendCustomMessage("clearCookies", list())
+        }
+        
         # Close the modal and the window
         shiny::removeModal()
         session$sendCustomMessage("closeWindow", list())
+    })
+
+    # Observer for restart survey functionality
+    shiny::observeEvent(input$restart_survey, {
+        # Update checkpoint 4 - when restarting survey
+        shiny::isolate({
+            update_data(time_last = TRUE)
+        })
+        
+        # Send force restart message to clear cookies and reload page
+        session$sendCustomMessage("forceRestart", list())
     })
 
     # Update checkpoint 5 - when session ends

--- a/inst/js/cookies.js
+++ b/inst/js/cookies.js
@@ -86,6 +86,34 @@ const surveydownCookies = {
             console.error("Error getting answer data:", e);
             return null;
         }
+    },
+
+    clear: function() {
+        try {
+            // Clear survey session cookie
+            document.cookie = "surveydown_session=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; SameSite=Strict";
+            
+            // Clear survey answers cookie  
+            document.cookie = "surveydown_answers=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; SameSite=Strict";
+            
+            console.log("Survey cookies cleared");
+        } catch (e) {
+            console.error("Error clearing survey cookies:", e);
+        }
+    },
+
+    forceRestart: function() {
+        try {
+            // Clear all survey cookies
+            this.clear();
+            
+            // Log restart action
+            console.log("Survey restart initiated");
+            
+            // Note: Page reload will be handled by the calling function
+        } catch (e) {
+            console.error("Error during force restart:", e);
+        }
     }
 };
 

--- a/man/sd_close.Rd
+++ b/man/sd_close.Rd
@@ -4,7 +4,14 @@
 \alias{sd_close}
 \title{Create a 'Close' Button to Exit the Survey}
 \usage{
-sd_close(label_close = NULL, label_previous = NULL, show_previous = NULL)
+sd_close(
+  label_close = NULL,
+  label_previous = NULL,
+  show_previous = NULL,
+  show_restart = FALSE,
+  label_restart = NULL,
+  clear_cookies = FALSE
+)
 }
 \arguments{
 \item{label_close}{Character string. The label of the 'Close' button. Defaults to
@@ -16,6 +23,16 @@ sd_close(label_close = NULL, label_previous = NULL, show_previous = NULL)
 \item{show_previous}{Logical. Whether to show the Previous button alongside the Close button.
 Set to \code{TRUE} to allow users to go back before closing. Defaults to \code{FALSE}. Note: Unlike
 \code{sd_nav()}, this parameter does NOT read from the \code{show-previous} YAML setting.}
+
+\item{show_restart}{Logical. Whether to show a 'Restart Survey' button alongside the
+Close button. When \code{TRUE}, displays two side-by-side buttons. Defaults to \code{FALSE}.}
+
+\item{label_restart}{Character string. The label for the 'Restart Survey' button.
+Defaults to \code{NULL}, which uses "Restart Survey" (or the translated equivalent).}
+
+\item{clear_cookies}{Logical. Whether to clear cookies on exit without showing a
+restart button. Use for use cases where the restart button isn't needed but
+cookies should be cleared for later resubmission. Defaults to \code{FALSE}.}
 }
 \value{
 A 'shiny' tagList containing the 'Close' button UI element and


### PR DESCRIPTION
This PR adds survey restart functionality, cookie-clearing options, and updates the exit flow in both the UI and server.

- Added new parameters to `sd_close()`:
  - `show_restart` — displays a Restart Survey button.
  - `label_restart` — allows customizing the restart button label.
  - `clear_cookies` — enables clearing cookies when the user exits.
- Added `"restart"` message to all supported languages in `R/messages.R`.
- Added new restart survey handler (`input$restart_survey`) in `R/server.R`.
- Added support for clearing cookies on exit (`clear_cookies_on_exit`) and new Shiny message handlers:
  - `clearCookies`
  - `forceRestart`
- Added new cookie utilities in `inst/js/cookies.js`:
  - `clear()`
  - `forceRestart()`

These changes allow surveys to be restarted cleanly, ensure cookies can be cleared when exiting, and improve consistency in how exit/restart events update data and client-side state.