### PR TITLE
Fix matrix row shuffling when Quarto post-processes table headers

### DIFF
--- a/R/server.R
+++ b/R/server.R
@@ -1439,10 +1439,17 @@ sd_server <- function(db = NULL) {
                         var tbodies = table.querySelectorAll('tbody');
                         var dataBody = null;
 
-                        // Find the tbody with actual data rows (has td elements, not just th)
+                        // Find the tbody with actual data rows, skipping header tbodies.
+                        // Quarto >= 1.7 uses <td data-quarto-table-cell-role='th'> instead of <th>,
+                        // so we must check for both formats to correctly skip the header tbody.
                         for (var i = 0; i < tbodies.length; i++) {
                             var firstRow = tbodies[i].querySelector('tr');
-                            if (firstRow && firstRow.querySelector('td')) {
+                            if (!firstRow) continue;
+                            var cells = firstRow.querySelectorAll('td, th');
+                            var thCount = firstRow.querySelectorAll('th').length;
+                            var quartoThCount = firstRow.querySelectorAll('[data-quarto-table-cell-role=\"th\"]').length;
+                            if (cells.length > 0 && (thCount === cells.length || quartoThCount === cells.length)) continue;
+                            if (firstRow.querySelector('td')) {
                                 dataBody = tbodies[i];
                                 break;
                             }


### PR DESCRIPTION
Comment by Hergie: this pull request was generated by Claude. The proposed fix works in my case but I am not a developer, so cannot critically evaluate whether this is the correct fix in a more general sense.

## Problem

  Matrix row shuffling silently fails: the `shuffled:` YAML setting works for MC-type questions but has no effect on matrix
  questions. Reported in https://github.com/orgs/surveydown-dev/discussions/250.

  ## Root cause

  `sd_question(type = "matrix")` generates a table with a bare `<tr>` header row containing `<th>` elements directly inside `<table>`    (not wrapped in `<thead>`). When Quarto's HTML table post-processor encounters this, it reorganizes the table into two `<tbody>`   sections and converts `<th>` to `<td data-quarto-table-cell-role="th">` (this is Quarto's workaround for Pandoc not preserving the th/td distinction).

  The JS in `create_matrix_shuffle_script` selects the data `<tbody>` by finding the first one whose first row contains a `<td>`:

  ```js
  if (firstRow && firstRow.querySelector('td')) {
      dataBody = tbodies[i];
      break;
  }
  ```

  After Quarto's post-processing, the header tbody also contains <td> elements (just with a data-quarto-table-cell-role attribute),
  so it matches first. That header tbody has only 1 row, so rows.length < 2 causes the shuffle to be silently skipped.

  The reason this may not reproduce on all machines is likely related to whether Quarto's table post-processing is active. See
  https://quarto.org/docs/authoring/tables.html#disabling-quarto-table-processing — this behavior can be disabled at the document,  cell, or table level.

##  Fix

  Before accepting a tbody as the data body, check whether all cells in its first row are header cells — either real <th>
  (pre-processing) or <td data-quarto-table-cell-role="th"> (post-processing). If so, skip it.

  This is backward-compatible: tables that were not post-processed by Quarto (with real <th> headers) are also correctly handled.

##  Testing

Verified on Windows with Quarto 1.7.32 against 4 matrix questions (2–7 rows each). Both the bug (old selector picks header tbody → shuffle skipped) and fix (new selector skips header tbody → shuffle proceeds) confirmed by simulating the JS DOM selection logic against the actual rendered HTML.
 